### PR TITLE
Fix example and minor typo in Readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ You can build a binary wheel using
 **Important**
 
 If you're using an older CUDA version you might get an error about ``'-allow-unsupported-compiler'`` not being a
-valid compiler option. In that case remove that compiler option from this projection's ``setup.py``.
+valid compiler option. In that case remove that compiler option from this project's ``setup.py``.
 
 Usage
 =====
@@ -62,21 +62,15 @@ Usage
 .. code-block:: python
 
     import pyronn_torch
+    import numpy as np
 
-    #ConeBeamProjector(volume_shape,
-    #                  volume_spacing,
-    #                  volume_origin,
-    #                  projection_shape,
-    #                  projection_spacing,
-    #                  projection_origin,
-    #                  projection_matrices)
     projector = pyronn_torch.ConeBeamProjector(
-        (128, 128, 128),
-        (2.0, 2.0, 2.0),
-        (-127.5, -127.5, -127.5),
-        (2, 480, 620),
-        [1.0, 1.0],
-        (0, 0),
+        (128, 128, 128),  # volume shape
+        (2.0, 2.0, 2.0),  # volume spacing in mm
+        (-127.5, -127.5, -127.5),  # volume origin in mm
+        (2, 480, 620),  # projection_shape (n, width, height)
+        [1.0, 1.0],  # projection_spacing in mm
+        (0, 0),  # projection_origin 
         np.array([[[-3.10e+2, -1.20e+03,  0.00e+00,  1.86e+5],
                    [-2.40e+2,  0.00e+00,  1.20e+03,  1.44e+5],
                    [-1.00e+00,  0.00e+00,  0.00e+00,  6.00e+2]],
@@ -85,11 +79,11 @@ Usage
                    [-2.39963440e+2, -4.18857765e+0,  1.20000000e+3,
                     1.44000000e+5],
                    [-9.99847710e-01, -1.74524058e-2,  0.00000000e+0,
-                    6.00000000e+2]]]) # two projection matrices
+                    6.00000000e+2]]])  # two projection matrices in shape (n, 3, 4)
     )
     projection = projector.new_projection_tensor(requires_grad=True)
 
-    projection += 1.
+    projection = projection + 1.
     result = projector.project_backward(projection, use_texture=True)
 
     assert projection.requires_grad


### PR DESCRIPTION
As discussed per mail; some cosmetic changes to the readme. Now the example should run through.

Changelog:
- l.56 projection -> project
- add `import numpy as np` to example
- remove old constructor and add comments to new one
- `projection += 1.` breaks as in-place operations are not allowed on leaf vars. Use assignment and `+` operator.

Cheers, 
Max