### PR TITLE
fix projection weighting, replace nullspace computation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ setup_requires = pyscaffold>=3.2a0,<3.3a0
 install_requires = 
     numpy>=1.19
     torch
-    sympy>=1.7
+    scipy
 # The usage of test_requires is discouraged, see `Dependency Management` docs
 # tests_require = pytest; pytest-cov
 # Require a specific Python version, e.g. Python 2.7 or >= 3.4

--- a/src/pyronn_torch/conebeam.py
+++ b/src/pyronn_torch/conebeam.py
@@ -222,7 +222,7 @@ class ConeBeamProjector:
             tuple(map(torch.from_numpy, inv_matrices))).float().cuda().contiguous()
         self._source_points = torch.stack(
             tuple(map(torch.from_numpy, source_points))).float().cuda().contiguous()
-        # todo need a special multiplier to get the weighting correct
+
         self._projection_multiplier = self._source_isocenter_distance * self._source_detector_distance * \
                                       self._projection_spacing[-1] * np.pi / self._projection_shape[0]
 


### PR DESCRIPTION
The constant projection weighting needs to be scaled to retain consistent gray values. 
Also, the null space implementation by scipy is faster than the one by sympy.